### PR TITLE
Fix pattern match for api_url match

### DIFF
--- a/bind/include/application/inc_soap_api.php
+++ b/bind/include/application/inc_soap_api.php
@@ -88,7 +88,7 @@ class soap_api
 		if (!isset($GLOBALS["config"]["api_host"]))
 		{
 			// need to set what the API hostname is for DNS lookups
-			preg_match("/^http[s]:\/\/(\S*?)[:0-9]*\//", $GLOBALS["config"]["api_url"], $matches);
+			preg_match("/^http[s]?:\/\/(\S*)[:0-9]*\//", $GLOBALS["config"]["api_url"], $matches);
 			$GLOBALS["config"]["api_host"] = $matches[1];
 		}
 


### PR DESCRIPTION
The pattern for pulling api_host out of api_url is incorrect, and fails if the URL is just a "http" protocol.  I have left the character class (i.e. [s]) in place as it is a visual clue that it is just the single character, where as the correct substring would either give some confusion (a lone 's?') or more characters ('(?:s)') and still be messy.