### PR TITLE
Fix Compitability with Apache 2.4

### DIFF
--- a/bind/include/amberphplib/inc_misc.php
+++ b/bind/include/amberphplib/inc_misc.php
@@ -1542,7 +1542,7 @@ function ipv4_split_to_class_c($address_with_cidr)
 	log_write("debug", "inc_misc", "Executing ipv4_split_to_class_c($address_with_cidr)");
 
 	// source range
-	$matches	= split("/", $address_with_cidr);
+	$matches	= explode("/", $address_with_cidr);
 
 	$src_addr	= $matches[0];
 	$src_cidr	= $matches[1];

--- a/bind/include/amberphplib/inc_security.php
+++ b/bind/include/amberphplib/inc_security.php
@@ -418,7 +418,7 @@ function security_form_input_predefined ($type, $valuename, $numchar, $errormsg)
 		break;
 
 		case "ipv6_cidr":
-			list($network, $cidr) = split("/", $_POST[$valuename]);
+			list($network, $cidr) = explode("/", $_POST[$valuename]);
 			
 			if (filter_var($network, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))
 			{

--- a/htdocs/include/amberphplib/inc_misc.php
+++ b/htdocs/include/amberphplib/inc_misc.php
@@ -1542,7 +1542,7 @@ function ipv4_split_to_class_c($address_with_cidr)
 	log_write("debug", "inc_misc", "Executing ipv4_split_to_class_c($address_with_cidr)");
 
 	// source range
-	$matches	= split("/", $address_with_cidr);
+	$matches	= explode("/", $address_with_cidr);
 
 	$src_addr	= $matches[0];
 	$src_cidr	= $matches[1];

--- a/htdocs/include/amberphplib/inc_security.php
+++ b/htdocs/include/amberphplib/inc_security.php
@@ -418,7 +418,7 @@ function security_form_input_predefined ($type, $valuename, $numchar, $errormsg)
 		break;
 
 		case "ipv6_cidr":
-			list($network, $cidr) = split("/", $_POST[$valuename]);
+			list($network, $cidr) = explode("/", $_POST[$valuename]);
 			
 			if (filter_var($network, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))
 			{

--- a/resources/namedmanager-httpdconfig.conf
+++ b/resources/namedmanager-httpdconfig.conf
@@ -6,8 +6,15 @@
 Alias /namedmanager /usr/share/namedmanager/htdocs
 
 <Location /namedmanager>
-	Order deny,allow
-	Allow from all
+   <IfModule mod_authz_core.c>
+     # Apache 2.4
+     Require all granted
+   </IfModule>
+   <IfModule !mod_authz_core.c>
+     # Apache 2.2
+     Order deny,allow
+     Allow from all
+   </IfModule>
 	AllowOverride all
 </Location>
 


### PR DESCRIPTION
small change needed to correctly work under apache 2.4 (Centos 7 ships with 2.4)
P.S : also replaced split function with explode to fix compatibility with php 7 (fixes issue #40)