### PR TITLE
hotfix for idn_to_ascii() using php7.4-intl

### DIFF
--- a/bind/include/application/inc_bind.php
+++ b/bind/include/application/inc_bind.php
@@ -502,7 +502,7 @@ class bind_api extends soap_api
 				if (function_exists("idn_to_ascii"))
 				{
 					$record["record_name"]		= idn_to_ascii($record["record_name"]);
-					$record["record_content"]	= idn_to_ascii($record["record_content"]);
+					$record["record_content"]	= idn_to_ascii($record["record_content"], IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
 				}
 
 				// handle origin and content format
@@ -537,7 +537,7 @@ class bind_api extends soap_api
 				if (function_exists("idn_to_ascii"))
 				{
 					$record["record_name"]		= idn_to_ascii($record["record_name"]);
-					$record["record_content"]	= idn_to_ascii($record["record_content"]);
+					$record["record_content"]	= idn_to_ascii($record["record_content"], IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
 				}
 
 				// handle origin and content format
@@ -570,7 +570,7 @@ class bind_api extends soap_api
 				if (function_exists("idn_to_ascii"))
 				{
 					$record["record_name"]		= idn_to_ascii($record["record_name"]);
-					$record["record_content"]	= idn_to_ascii($record["record_content"]);
+					$record["record_content"]	= idn_to_ascii($record["record_content"], IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
 				}
 
 				if (strpos($record["record_name"], "ip6.arpa"))
@@ -597,7 +597,7 @@ class bind_api extends soap_api
 				if (function_exists("idn_to_ascii"))
 				{
 					$record["record_name"]		= idn_to_ascii($record["record_name"]);
-					$record["record_content"]	= idn_to_ascii($record["record_content"]);
+					$record["record_content"]	= idn_to_ascii($record["record_content"], IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
 				}
 
 				if (preg_match("/\./", $record["record_name"]) && preg_match("/". $domain_name ."$/", $record["record_name"]))
@@ -638,7 +638,7 @@ class bind_api extends soap_api
 
 					// idn_to_ascii has a lovely habit of blowing up with some record values, such as
 					// DKIM records. If idn_to_ascii fails, we leave the value unchanged
-					if ($tmp = idn_to_ascii($record["record_content"]))
+					if ($tmp = idn_to_ascii($record["record_content"], IDNA_DEFAULT, INTL_IDNA_VARIANT_2003))
 					{
 						$record["record_content"] = $tmp;
 					}

--- a/htdocs/include/application/inc_domain.php
+++ b/htdocs/include/application/inc_domain.php
@@ -326,7 +326,7 @@ class domain
 				if ($this->format == 'idn')
 				{
 					$data_records["name"]		= idn_to_ascii($data_records["name"]);
-					$data_records["content"]	= idn_to_ascii($data_records["content"]);
+					$data_records["content"]	= idn_to_ascii($data_records["content"], IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
 				}
 
 				$this->data["records"][] = $data_records;


### PR DESCRIPTION
Up to php7.2-intl the default variant of idn_to_ascii() was `INTL_IDNA_VARIANT_2003`.
From php7.4-intl the default variant is `INTL_IDNA_VARIANT_UTS46`.
(see https://www.php.net/manual/de/function.idn-to-ascii.php and https://www.php.net/manual/de/migration72.deprecated.php)

This PR ensures that the old variant is still used, as the new one is no longer case sensitive, which is, however, required for some DNS entries.

fixes #92